### PR TITLE
Elixir support via coc-elixir

### DIFF
--- a/config/coc.vim
+++ b/config/coc.vim
@@ -3,7 +3,8 @@ let g:coc_global_extensions = [
   \'coc-snippets',
   \'coc-json',
   \'coc-conjure',
-  \'coc-actions']
+  \'coc-actions',
+  \'coc-elixir']
 
 let g:coc_snippet_next = '<tab>'
 
@@ -59,6 +60,8 @@ xmap <leader>fs  <Plug>(coc-format-selected)
 
 " Add `:OR` command for organize imports of the current buffer.
 command! -nargs=0 OR   :call CocAction('runCommand', 'editor.action.organizeImport')
+
+nnoremap <silent> <leader>co  :<C-u>CocList outline<CR>
 
 " to navigate with tab
 inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "\<Tab>"

--- a/init.vim
+++ b/init.vim
@@ -27,7 +27,7 @@ Plug 'neoclide/coc.nvim', { 'branch': 'release' }
 Plug 'tpope/vim-fugitive'
 
 " tests
-Plug 'vim-test/vim-test', { 'for': 'dart' }
+Plug 'vim-test/vim-test', { 'for': ['dart', 'elixir'] }
 
 " fennel
 Plug 'Olical/aniseed', { 'tag': 'v3.6.2', 'for': 'fennel' }
@@ -53,6 +53,10 @@ Plug 'rust-lang/rust.vim'
 
 " flutter
 Plug 'dart-lang/dart-vim-plugin'
+
+" elixir
+Plug 'elixir-lsp/coc-elixir', {'do': 'yarn install && yarn prepack'}
+Plug 'elixir-editors/vim-elixir'
 
 " utils
 Plug 'editorconfig/editorconfig-vim'


### PR DESCRIPTION
### Context

Add support to Elixir using `coc-elixir`.
Also enables `vim-test` for Elixir to run tests.

And for bonus, add a shortcut to list current methods of module and works for Clojure too!